### PR TITLE
use configured baseUrl instead of app url

### DIFF
--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -376,7 +376,7 @@ trait MakesHttpRequests
         }
 
         if (! Str::startsWith($uri, 'http')) {
-            $uri = config('app.url').'/'.$uri;
+            $uri = $this->baseUrl.'/'.$uri;
         }
 
         return trim($uri, '/');


### PR DESCRIPTION
Lumen reads the $baseUrl from `Laravel\Lumen\Testing\TestCase` rather than from the config. 

With the change I made, you can set a baseUrl like `protected $baseUrl = 'http://localhost/v2';` rather than prefixing every URL with "v2", which is pretty handy. 

https://github.com/laravel/lumen-framework/blob/5.6/src/Testing/Concerns/MakesHttpRequests.php#L358