### PR TITLE
Fix for Issue 13, could not send parameters to json endpoints

### DIFF
--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -338,8 +338,10 @@ trait MakesHttpRequests
             $cookies, $files, $server, $content
         );
 
+        $this->app['request'] = Request::createFromBase($symfonyRequest);
+
         $response = $this->app->prepareResponse(
-            $this->app->handle(Request::createFromBase($symfonyRequest))
+            $this->app->handle($this->app['request'])
         );
         $this->response = $this->createTestResponse($response);
 


### PR DESCRIPTION
This should fix the problems that parameters in tests like these, do not end up in the controller:
```php
$this->json('GET', '/something', ['var' => 'x']);
```

With this change you can again just do this in your Controller, and it will work:
```php
$input = $this->validate($request, [
  'var' => 'required',
]);
```

With the default AlbertCht\lumen-testing the above would fail with `var.required`, even though you set it.

Fixes: https://github.com/albertcht/lumen-testing/issues/13