### PR TITLE
Add testing for Lumen 5.7, 5.8 and 6.x, plus PHP 7.1-7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,27 @@
 language: php
-dist: trusty
+dist: bionic
 sudo: false
 
 matrix:
   include:
-    - php: 7.2
+    - php: 7.1
       env: FRAMEWORK_VERSION=laravel/lumen-framework:5.3.*
-    - php: 7.2
+    - php: 7.1
       env: FRAMEWORK_VERSION=laravel/lumen-framework:5.4.*
-    - php: 7.2
+    - php: 7.1
       env: FRAMEWORK_VERSION=laravel/lumen-framework:5.5.*
     - php: 7.1
       env: FRAMEWORK_VERSION=laravel/lumen-framework:5.6.*
+    - php: 7.1
+      env: FRAMEWORK_VERSION=laravel/lumen-framework:5.7.*
+    - php: 7.1
+      env: FRAMEWORK_VERSION=laravel/lumen-framework:5.8.*
+    - php: 7.2
+      env: FRAMEWORK_VERSION=laravel/lumen-framework:6.*
+    - php: 7.3
+      env: FRAMEWORK_VERSION=laravel/lumen-framework:6.*
+    - php: 7.4
+      env: FRAMEWORK_VERSION=laravel/lumen-framework:6.*
 
 install:
   - composer require "${FRAMEWORK_VERSION}" --no-update -n


### PR DESCRIPTION
Upgrade distro to bionic (Ubuntu 18.04 LTS) so we have PHP 7.1-7.4 available:

https://docs.travis-ci.com/user/languages/php/#choosing-php-versions-to-test-against

I notice that Travis CI doesn't quite seem to know that tests have ended. Not sure if this fixes anything.